### PR TITLE
fixed migration

### DIFF
--- a/migrations/2015_04_29_233700_create_table_urls.php
+++ b/migrations/2015_04_29_233700_create_table_urls.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateTableURLs extends Migration
+class CreateTableUrls extends Migration
 {
 
     /**


### PR DESCRIPTION
While running a `migration:refresh` the resolver of names use CamelCase format to retrieve the classes from which run down() functions. This fix permits to match the filename `create_table_urls` to the class name `CreateTableUrls`
